### PR TITLE
feat: no download

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout files
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Derive semver version number based on git revision
         shell: pwsh

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet tool install -g Octopus.OctoVersion.Tool
-          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment >> $GITHUB_ENV
+          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment
 
       - name: Lint sources
         shell: pwsh

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,10 +8,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout files
+        uses: actions/checkout@v4
 
-    - name: Checkout files
-      uses: actions/checkout@v3
+      - name: Derive semver version number based on git revision
+        shell: pwsh
+        run: |
+          dotnet tool install -g Octopus.OctoVersion.Tool
+          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment >> $GITHUB_ENV
 
-    - name: Lint sources
-      shell: pwsh
-      run: Invoke-ScriptAnalyzer -Recurse -Severity Warning ./src
+      - name: Lint sources
+        shell: pwsh
+        run: Invoke-ScriptAnalyzer -Recurse -Severity Warning ./src

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,7 +17,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet tool install -g Octopus.OctoVersion.Tool
-          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment
+          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment >> $GITHUB_ENV
 
       - name: Lint sources
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout files
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Derive semver version number based on git revision
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,19 @@ jobs:
   release:
     runs-on: windows-latest
     steps:
+      - name: Checkout files
+        uses: actions/checkout@v4
 
-      - uses: actions/checkout@v3
-
-      - name: Get new version
-        id: new-version
-        uses: arwynfr/actions-conventional-versioning/get-newVersion@v3
-        with:
-          allow-additional-modifiers: true
-          feat-upgrades-minor: false
-          strict-types: true
+      - name: Derive semver version number based on git revision
+        shell: pwsh
+        run: |
+          dotnet tool install -g Octopus.OctoVersion.Tool
+          octoversion --CurrentBranch=${{ github.ref_name }} --OutputFormats:0=Environment >> $GITHUB_ENV
 
       - name: Publish module on PSGallery
         shell: pwsh
-        run: build/Release.ps1 -Version ${{ steps.new-version.outputs.next-version }} -ApiKey ${{ secrets.PSGALLERY_APIKEY }} -Verbose
+        run: build/Release.ps1 -Version ${env:OCTOVERSION_FullSemVer} -ApiKey ${{ secrets.PSGALLERY_APIKEY }} -Verbose
 
       - name: Tag new version on the repository
-        uses: arwynfr/actions-conventional-versioning@v3
-        with:
-          allow-additional-modifiers: true
-          feat-upgrades-minor: false
-          strict-types: true
+        shell: pwsh
+        run: gh release create ${env:OCTOVERSION_FullSemVer} --generate-notes

--- a/src/Install-ArmaServer.ps1
+++ b/src/Install-ArmaServer.ps1
@@ -3,7 +3,10 @@ param (
   [Parameter(Mandatory)]
   [ValidateScript({ Test-Path $_ -PathType Leaf }, ErrorMessage = 'Filename not found')]
   [string]
-  $ConfigFilename
+  $ConfigFilename,
+
+  [switch]
+  $NoDownload
 )
 
 Begin {
@@ -19,7 +22,9 @@ End {
   New-Item $Config.WorkshopPath -ItemType Directory -Force | Out-Null
   New-Item $KeysPath -ItemType Directory -Force | Out-Null
   Get-ChildItem -Recurse -Filter *.bikey $KeysPath | Remove-Item -Force
-  $Addons | ArmaServer-InvokeDownload -MasterPath $Config.MasterPath -WorkshopPath $Config.WorkshopPath -Beta $Config.Beta -Quit
+  if (-not $NoDownload) {
+    $Addons | ArmaServer-InvokeDownload -MasterPath $Config.MasterPath -WorkshopPath $Config.WorkshopPath -Beta $Config.Beta -Quit
+  }
   $Addons | ArmaServer-InstallBohemiaKeys -DestinationPath $KeysPath -WorkshopPath $Config.WorkshopPath
   $Config.Missions | ArmaServer-InstallMission -DestinationPath $MissionsPath
   ArmaServer-InstallConfig -ConfigFilename $ConfigFilename


### PR DESCRIPTION
This PR adds a -NoDownload switch to Install-ArmaServer.
This allows to update the server configuration without redownloading mods and binaries.

Also this mods upgrades the github actions to checkout v4 and use octoversion from semver calculations.